### PR TITLE
Master

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,5 +11,5 @@ Description: Functions to perform Phenome Wide Association
  codes (v1.2), statistical analysis, and plotting.
 License: GPL-3
 Depends: dplyr, tidyr, ggplot2 (>= 0.9.3), parallel
-Imports: MASS, meta
+Imports: MASS, meta, ggrepel
 LazyData: yes

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,3 +2,4 @@ export(phewas, mapICD9toPheWAS, mapPheWAStoExclusions, createPhewasTable, phenot
 import(dplyr,tidyr, ggplot2, parallel)
 importFrom(MASS,mvrnorm)
 importFrom(meta,metagen)
+importFrom(ggrepel,geom_text_repel)

--- a/R/phenotypePlot.R
+++ b/R/phenotypePlot.R
@@ -271,9 +271,9 @@ phenotypePlot <-
         warning("Annotation requested, but no points met criteria")
       } else {
         #Add annotations
-        if(annotate.phenotype.description|annotate.phenotype|annotate.snp.w.phenotype) plot = plot + geom_text(aes(label=description),colour="black",data=d[d$annotate,],hjust=0,size=annotate.size,angle=annotate.angle)
+        if(annotate.phenotype.description|annotate.phenotype|annotate.snp.w.phenotype) plot = plot + geom_text_repel(aes(label=description),colour="black",data=d[d$annotate,],size=annotate.size,angle=annotate.angle)
         #Add SNP annotations
-        if(annotate.snp) plot = plot + geom_text(aes(label=snp),colour="black",data=d[d$annotate,],hjust=0,size=annotate.size,angle=annotate.snp.angle)
+        if(annotate.snp) plot = plot + geom_text_repel(aes(label=snp),colour="black",data=d[d$annotate,],size=annotate.size,angle=annotate.snp.angle)
       }
     } 
     

--- a/R/phenotypePlot.R
+++ b/R/phenotypePlot.R
@@ -271,9 +271,9 @@ phenotypePlot <-
         warning("Annotation requested, but no points met criteria")
       } else {
         #Add annotations
-        if(annotate.phenotype.description|annotate.phenotype|annotate.snp.w.phenotype) plot = plot + geom_text_repel(aes(label=description),colour="black",data=d[d$annotate,],size=annotate.size,angle=annotate.angle)
+        if(annotate.phenotype.description|annotate.phenotype|annotate.snp.w.phenotype) plot = plot + ggrepel::geom_text_repel(aes(label=description),colour="black",data=d[d$annotate,],size=annotate.size,angle=annotate.angle)
         #Add SNP annotations
-        if(annotate.snp) plot = plot + geom_text_repel(aes(label=snp),colour="black",data=d[d$annotate,],size=annotate.size,angle=annotate.snp.angle)
+        if(annotate.snp) plot = plot + ggrepel::geom_text_repel(aes(label=snp),colour="black",data=d[d$annotate,],size=annotate.size,angle=annotate.snp.angle)
       }
     } 
     


### PR DESCRIPTION
The datapoint labels on the Manhattan plot used to overlap with each other (when there were more than one close to each other) or go beyond the boundary of the graph (if they were too close to the side). Using the ggrepel package, I’ve made a small edit to phenotypePlot that fixes this problem.