### PR TITLE
0.99.5-2

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: PheWAS
 Type: Package
 Title: Phenome Wide Association Studies (PheWAS)
-Version: 0.99.5
-Date: 2019-07-25
+Version: 0.99.5-1
+Date: 2019-08-09
 Author: Robert Carroll, Josh Denny, Lisa Bastarache, Laura Wiley
 Maintainer: Robert Carroll <Robert.Carroll@vumc.org>
 URL: http://www.ncbi.nlm.nih.gov/pubmed/24733291

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: PheWAS
 Type: Package
 Title: Phenome Wide Association Studies (PheWAS)
-Version: 0.99.5-1
-Date: 2019-08-09
+Version: 0.99.5-2
+Date: 2019-08-15
 Author: Robert Carroll, Josh Denny, Lisa Bastarache, Laura Wiley
 Maintainer: Robert Carroll <Robert.Carroll@vumc.org>
 URL: http://www.ncbi.nlm.nih.gov/pubmed/24733291

--- a/R/phe_as.R
+++ b/R/phe_as.R
@@ -35,7 +35,7 @@ function(phe.gen, additive.genotypes=T,min.records=20,return.models=F,confint.le
   type=NA_character_
   note=""
   model=NA
-  model_name=sprintf("No model: %s ~ %s",phe,paste0(names(data)[-1],collapse = " + "))
+  model_name=sprintf("No model: %s ~ %s",phe,paste0(names(d)[-1],collapse = " + "))
   if(n_total<min.records) {
     note=paste(note,"[Error: <",min.records," complete records]")
   } else if(length(unique(na.omit(d[[phe]])))<=1 | length(unique(na.omit(d[[gen]]))) <=1) {
@@ -141,7 +141,8 @@ function(phe.gen, additive.genotypes=T,min.records=20,return.models=F,confint.le
   #If the complete models were requested, add them as well.
   if(return.models) {
     attributes(output)$model=model
-    attributes(output)$model_name=model_name}
+    attributes(output)$model_name=model_name
+  }
   attributes(output)$successful.phenotype=ifelse(is.na(p),NA,phe_o)
   attributes(output)$successful.genotype=ifelse(is.na(p),NA,gen)
   #Return this to the loop to be merged.

--- a/R/phe_as.R
+++ b/R/phe_as.R
@@ -103,14 +103,6 @@ function(phe.gen, additive.genotypes=T,min.records=20,return.models=F,confint.le
     }
   }
   
-  #Check to see there were numbers (ie phewas codes) as the predictor, and clean up.
-  if(suppressWarnings(!is.na(as.numeric(gen)))){
-    gens=substring(gens,2)
-    #Clean up if there was just one TRUE entry
-    if(length(gens)==1 & substring(gens,length(gens)-4)=="TRUE") {
-      gens=substring(gens,1,length(gens)-4)
-    }
-  }
   output=data.frame(phenotype=phe_o,snp=gens,
                     adjustment=adjustment,
                     beta=beta, SE=se,

--- a/R/phe_as.R
+++ b/R/phe_as.R
@@ -35,6 +35,7 @@ function(phe.gen, additive.genotypes=T,min.records=20,return.models=F,confint.le
   type=NA_character_
   note=""
   model=NA
+  model_name=sprintf("No model: %s ~ %s",phe,paste0(names(data)[-1],collapse = " + "))
   if(n_total<min.records) {
     note=paste(note,"[Error: <",min.records," complete records]")
   } else if(length(unique(na.omit(d[[phe]])))<=1 | length(unique(na.omit(d[[gen]]))) <=1) {
@@ -67,6 +68,7 @@ function(phe.gen, additive.genotypes=T,min.records=20,return.models=F,confint.le
       else {
         model = glm(as.formula(paste(phe," ~ .")), data=d, family=binomial)
         modsum= summary(model)
+        model_name=paste0(as.character(terms(model))[c(2,1,3)],collapse=" ")
         #If the models did not converge, report NA values instead.
         if(model$converged) {
           #Find the rows with results that gets merged across all loops
@@ -86,8 +88,9 @@ function(phe.gen, additive.genotypes=T,min.records=20,return.models=F,confint.le
         note=paste(note,"[Error: <",min.records," records with phenotype and genotype]")
       } else {
         model = glm(as.formula(paste(phe," ~ .", sep="", collapse="")), data=d)
-  
         modsum= summary(model)
+        model_name=paste0(as.character(terms(model))[c(2,1,3)],collapse=" ")
+        
         #If the models did not converge, report NA values instead.
         if(model$converged) {
           #Find the rows with results that gets merged across all loops
@@ -136,7 +139,9 @@ function(phe.gen, additive.genotypes=T,min.records=20,return.models=F,confint.le
   }
   
   #If the complete models were requested, add them as well.
-  if(return.models) {attributes(output)$model=model}
+  if(return.models) {
+    attributes(output)$model=model
+    attributes(output)$model_name=model_name}
   attributes(output)$successful.phenotype=ifelse(is.na(p),NA,phe_o)
   attributes(output)$successful.genotype=ifelse(is.na(p),NA,gen)
   #Return this to the loop to be merged.

--- a/R/phewas.R
+++ b/R/phewas.R
@@ -79,10 +79,7 @@ function(phenotypes,genotypes,data,covariates=c(NA),adjustments=list(NA), outcom
   if(return.models) {
     message("Collecting models...")
     models=lapply(result,function(x){attributes(x)$model})
-    names(models)=sapply(models,function(x){
-      if(length(x)==1&&is.na(x)){NA_character_}
-      else{paste0(as.character(terms(x))[c(2,1,3)],collapse=" ")}
-        })
+    names(models)=sapply(models,function(x){attributes(x)$model_name})
   }
   
   message("Compiling results...")

--- a/R/phewas.R
+++ b/R/phewas.R
@@ -161,7 +161,7 @@ function(phenotypes,genotypes,data,covariates=c(NA),adjustments=list(NA), outcom
   
   #Refine the names for phecode predictors if requested
   if(clean.phecode.predictors) {
-    sig$snp=sub("`([0-9.]+)`.*","\\1",sig$snp)
+    sig$snp=sub("`([0-9.]+)`(TRUE)?","\\1",sig$snp)
   }
   
   if(!missing(outcomes)) names(sig)[names(sig)=="phenotype"]="outcome"

--- a/R/phewas.R
+++ b/R/phewas.R
@@ -166,7 +166,7 @@ function(phenotypes,genotypes,data,covariates=c(NA),adjustments=list(NA), outcom
   
   if(!missing(outcomes)) names(sig)[names(sig)=="phenotype"]="outcome"
   if(!missing(predictors)) names(sig)[names(sig)=="snp"]="predictor"
-  if(return.models){sig=list(results=sig,models=models)}
+
   if(!missing(quick.confint.level)) {
     if(quick.confint.level>=1|quick.confint.level<=0) {warning("Quick confidence interval requested, but a value in the range (0,1) was not supplied")}
     else {
@@ -178,5 +178,8 @@ function(phenotypes,genotypes,data,covariates=c(NA),adjustments=list(NA), outcom
       sig=sig[,c(sig.names[1:5],"lower.q","upper.q",sig.names[6:length(sig.names)])]
     }
   }
+  
+  if(return.models){sig=list(results=sig,models=models)}
+  
   return(sig)
 }

--- a/R/phewas.R
+++ b/R/phewas.R
@@ -79,7 +79,7 @@ function(phenotypes,genotypes,data,covariates=c(NA),adjustments=list(NA), outcom
   if(return.models) {
     message("Collecting models...")
     models=lapply(result,function(x){attributes(x)$model})
-    names(models)=sapply(models,function(x){attributes(x)$model_name})
+    names(models)=sapply(result,function(x){attributes(x)$model_name})
   }
   
   message("Compiling results...")

--- a/R/phewas.R
+++ b/R/phewas.R
@@ -1,6 +1,7 @@
 phewas <-
 function(phenotypes,genotypes,data,covariates=c(NA),adjustments=list(NA), outcomes, predictors, cores=1, additive.genotypes=T, 
-         significance.threshold, alpha=0.05, unadjusted=F, return.models=F, min.records=20, MASS.confint.level=NA,quick.confint.level) {
+         significance.threshold, alpha=0.05, unadjusted=F, return.models=F, min.records=20, MASS.confint.level=NA,quick.confint.level,
+         clean.phecode.predictors=F) {
   if(missing(phenotypes)) {
     if(!missing(outcomes)) phenotypes=outcomes
     else stop("Either phenotypes or outcomes must be passed in.")
@@ -78,7 +79,10 @@ function(phenotypes,genotypes,data,covariates=c(NA),adjustments=list(NA), outcom
   if(return.models) {
     message("Collecting models...")
     models=lapply(result,function(x){attributes(x)$model})
-    names(models)=sapply(models,function(x){paste0(as.character(terms(x))[c(2,1,3)],collapse=" ")})
+    names(models)=sapply(models,function(x){
+      if(length(x)==1&&is.na(x)){NA_character_}
+      else{paste0(as.character(terms(x))[c(2,1,3)],collapse=" ")}
+        })
   }
   
   message("Compiling results...")
@@ -157,6 +161,12 @@ function(phenotypes,genotypes,data,covariates=c(NA),adjustments=list(NA), outcom
       attributes(sig)$simplem.product.meff=sm
     }
   }
+  
+  #Refine the names for phecode predictors if requested
+  if(clean.phecode.predictors) {
+    sig$snp=sub("`([0-9.]+)`.*","\\1",sig$snp)
+  }
+  
   if(!missing(outcomes)) names(sig)[names(sig)=="phenotype"]="outcome"
   if(!missing(predictors)) names(sig)[names(sig)=="snp"]="predictor"
   if(return.models){sig=list(results=sig,models=models)}

--- a/man/phewas-package.Rd
+++ b/man/phewas-package.Rd
@@ -12,8 +12,8 @@ This package provides the tools necessary to perform a PheWAS analysis.
 \tabular{ll}{
 Package: \tab PheWAS\cr
 Type: \tab Package\cr
-Version: \tab 0.99.5\cr
-Date: \tab 2019-07-25\cr
+Version: \tab 0.99.5-1\cr
+Date: \tab 2019-08-09\cr
 License: \tab GPL3\cr
 }
 This package contains the mappings and information for phecodes version 1.2 (ICD9CM) and the 2018 beta version of ICD10CM.

--- a/man/phewas-package.Rd
+++ b/man/phewas-package.Rd
@@ -12,8 +12,8 @@ This package provides the tools necessary to perform a PheWAS analysis.
 \tabular{ll}{
 Package: \tab PheWAS\cr
 Type: \tab Package\cr
-Version: \tab 0.99.5-1\cr
-Date: \tab 2019-08-09\cr
+Version: \tab 0.99.5-2\cr
+Date: \tab 2019-08-15\cr
 License: \tab GPL3\cr
 }
 This package contains the mappings and information for phecodes version 1.2 (ICD9CM) and the 2018 beta version of ICD10CM.

--- a/man/phewas.Rd
+++ b/man/phewas.Rd
@@ -65,7 +65,7 @@ Uses the \code{MASS} package and the \code{confint} function to calculate a conf
 Calculate a confidence interval based on \code{beta + or - qnorm * SE}. Output is stored in the \code{lower.q} and \code{upper.q} columns. Logistic models will return have the exponentiated OR confidence intervals.
 }
   \item{clean.phecode.predictors}{
-If phecodes are used as predictors, this option will enable a result post-processing step that will alter the snp/predictor column to contain only the phecode. It defaults to \code{FALSE} as this provides the best clarity.
+If phecodes are used as predictors, this option will enable a result post-processing step that will alter the snp/predictor column to contain only the phecode. It defaults to \code{FALSE} as this provides the best clarity. Clean phecodes likely indicate either continuous input or a boolean TRUE. The actual code is: \code{sub("`([0-9.]+)`(TRUE)?","\\\\1",predictor)}
 }
 }
 \details{

--- a/man/phewas.Rd
+++ b/man/phewas.Rd
@@ -11,7 +11,9 @@ This function will perform a PheWAS analysis, optionally adjusting for other var
 phewas(phenotypes, genotypes, data, covariates = c(NA), adjustments = list(NA), 
   outcomes, predictors, cores = 1, additive.genotypes = T, 
   significance.threshold, alpha = 0.05, unadjusted = F, return.models = F,
-  min.records = 20, MASS.confint.level=NA, quick.confint.level)
+  min.records = 20, MASS.confint.level=NA, quick.confint.level,
+  clean.phecode.predictors=F
+  )
 }
 \arguments{
   \item{phenotypes}{
@@ -61,6 +63,9 @@ Uses the \code{MASS} package and the \code{confint} function to calculate a conf
 }
   \item{quick.confint.level}{
 Calculate a confidence interval based on \code{beta + or - qnorm * SE}. Output is stored in the \code{lower.q} and \code{upper.q} columns. Logistic models will return have the exponentiated OR confidence intervals.
+}
+  \item{clean.phecode.predictors}{
+If phecodes are used as predictors, this option will enable a result post-processing step that will alter the snp/predictor column to contain only the phecode. It defaults to \code{FALSE} as this provides the best clarity.
 }
 }
 \details{


### PR DESCRIPTION
This PR corrects some bad behavior for return.models and how phecode names are used as predictors. It introduces a new parameter "clean.phecode.predictors" that will optionally allow nicer (albeit potentially confusing) predictor names for phecodes. See the documentation for more details.