### PR TITLE
Add warning for mapping changes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: PheWAS
 Type: Package
 Title: Phenome Wide Association Studies (PheWAS)
-Version: 0.99.6
+Version: 0.99.6-1
 Date: 2023-05-31
 Author: Robert Carroll, Josh Denny, Lisa Bastarache, Laura Wiley
 Maintainer: Robert Carroll <Robert.Carroll@vumc.org>

--- a/R/createPhenotypes.R
+++ b/R/createPhenotypes.R
@@ -26,6 +26,13 @@ createPhenotypes <-
       phemapped=mapCodesToPhecodes(id.vocab.code.index, make.distinct=map.codes.make.distinct, vocabulary.map=vocabulary.map, rollup.map=rollup.map) %>% transmute(id, code=phecode, index)
     }
     
+    #Warn if there are ICD9CM and ICD10CM codes and numeric indexes, but default aggregation and code count settings
+    if(missing(aggregate.fun) & map.codes.make.distinct == FALSE & min.code.count==2 &
+       is.numeric(id.vocab.code.index[[4]]) & 
+       "ICD9CM" %in% id.vocab.code.index[[2]] & "ICD10CM" %in% id.vocab.code.index[[2]] ) {
+         warning("You are using ICD9CM and ICD10CM codes and numeric counts as an index. With default settings, individuals dual-coded on a single day with ICD9CM and ICD10CM codes that indicate a single phecode will meet a minimum code count of 2, as each code counts separately. Consider providing dates as an index instead. If that's not possible, be sure to evaluate the scientific impacts and consider adjusting `min.code.count`, `map.codes.make.distinct`, or `aggregate.fun`.")
+       }
+    
     message("Aggregating codes...")
     phecode=ungroup(summarize(group_by(phemapped,id,code),count=aggregate.fun(index)))
     phecode=phecode[phecode$count>0,]

--- a/man/createPhenotypes.Rd
+++ b/man/createPhenotypes.Rd
@@ -58,7 +58,7 @@ Map between phecodes and their exclusions. By default uses the PheWAS::phecode_e
 Map that specifies sex-specific phecodes. By default uses the PheWAS::sex_restriction.
 }
   \item{map.codes.make.distinct}{
-Controls the \code{make.distinct} flag for the internal \code{mapCodesToPhecodes} function. The default works well with the default \code{aggregate.fun}, which handles counting distinct dates. Included primarily to support replicating from prior builds. By default FALSE.
+Controls the \code{make.distinct} flag for the internal \code{mapCodesToPhecodes} function. The default works well with the default \code{aggregate.fun}, which handles counting distinct dates. Included primarily to support replicating from prior builds or to support possible dual-coding concerns. By default FALSE.
 }
 }
 \details{

--- a/man/phewas-package.Rd
+++ b/man/phewas-package.Rd
@@ -12,7 +12,7 @@ This package provides the tools necessary to perform a PheWAS analysis.
 \tabular{ll}{
 Package: \tab PheWAS\cr
 Type: \tab Package\cr
-Version: \tab 0.99.6\cr
+Version: \tab 0.99.6-1\cr
 Date: \tab 2023-05-31\cr
 License: \tab GPL3\cr
 }


### PR DESCRIPTION
This patch adds a warning for potential impacts of dual-coded mapping with the no-longer-distinct default.