### PR TITLE
adding a dockerfile as an alternative method of installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,6 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # ENV PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig
-RUN R -e "install.packages('devtools')"
+RUN R -e "install.packages('devtools', Ncpus=4)"
 RUN R -e "library(devtools);install_github('PheWAS/PheWAS')"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM r-base:4.4.0
+
+RUN apt-get update \
+  && apt-get install -y pkg-config bzip2 curl openssl \
+  libcurl4-openssl-dev libssl-dev libxml2-dev libgit2-dev \
+  libfontconfig1-dev libfreetype-dev libexpat1 libexpat1-dev \
+  cmake libharfbuzz-dev libfribidi-dev libxml2-dev libtiff-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+# ENV PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig
+RUN R -e "install.packages('devtools')"
+RUN R -e "library(devtools);install_github('PheWAS/PheWAS')"
+

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # PheWAS
-The PheWAS R package is designed to provide an accessible interface to the phenome wide association study. 
+
+The PheWAS R package is designed to provide an accessible interface to the phenome wide association study.
 For a description of the methods available and some simple examples, please see the
-[package vignette](https://github.com/PheWAS/PheWAS/blob/master/inst/doc/PheWAS-package.pdf?raw=true) or the R documentation. 
+[package vignette](https://github.com/PheWAS/PheWAS/blob/master/inst/doc/PheWAS-package.pdf?raw=true) or the R documentation.
 For installation help, see below.
-##Installing the PheWAS Package
+
+## Installing the PheWAS Package
+
 The PheWAS package can be installed using the devtools package. The following code when executed in R will get you started:
+
 ```
 install.packages("devtools")
 #It may be necessary to install required as not all package dependencies are installed by devtools:
@@ -12,8 +16,22 @@ install.packages(c("dplyr","tidyr","ggplot2","MASS","meta","ggrepel","DT"))
 devtools::install_github("PheWAS/PheWAS")
 library(PheWAS)
 ```
+
 Note that some versions of devtools do not install all dependencies, so one may need to install those using install.packages() first if there is an error.
 
 You can additionally view the package help or vignette in R:
+
 - `?PheWAS`
 - `vignette("PheWAS-package")`
+
+### Installing with Docker
+
+A Dockerfile has been provided as an additional method of installing the PheWAS package. The file is built on top of the r-base:4.4.0 image and is designed to facillate use of the PheWAS package in the cloud or in environments where users are encountering installation permission errors. Users can build the docker image using the following command:
+
+```
+#build docker image from file
+docker build -t {insert custom tag name} .
+
+#run the docker image and show the PheWAS documentation
+docker run --rm -it {image id #} R -e "library(PheWAS);?PheWAS"
+```


### PR DESCRIPTION
### Background for proposed addition:
Over the past few weeks, I have encountered several errors while trying to install the PheWAS package using devtools or while trying to help people who wanted to install the PheWAS package. These errors have resulted usually from the following two issues:

1. internal linking or inclusion error in one of the dependency files
2. issue specifying the proper installation directory using devtools on HPC environments such as ACCRE at Vanderbilt 

These issues are addressable but require the user to have some familarity with linking and inclusion of files in c++ compilation or to manually specify the installation library for R on the HPC.

### Proposed change:
This change adds a Dockerfile that can be used by Docker (or Podman) to install the tool. The image is based on the r-base:4.4.0 base image and follows similar installation instructions as describe on the [PheWAS page](https://www.vumc.org/cpm/center-precision-medicine-blog/phewas-r-package). Additionally updated the README to show how to build the docker image from the file

### Benefits of the change:
* Adds one more installation method so users can sucessfully use the tool. 
* Removes some of the platform architecture differences that can affect c++ build systems so that hopefully the (relatively small) percentage of users encountering these issues can successfully install the program
* enables easier use in the cloud within WDL scripts

### Has this been tested?:
This image has been built both on Ubuntu 24.04.3 LTS (amd64 architecture) and macOS Sequoia 15.5 (arm64, M2 chip) with both Docker and Podman and Singularity

